### PR TITLE
Removes blur from `frontend-egui`

### DIFF
--- a/frontend-egui/Cargo.toml
+++ b/frontend-egui/Cargo.toml
@@ -7,7 +7,8 @@ default-run = "frontend-egui"
 
 [dependencies]
 fearless_nes = { path = "../nes", features = ["debug_tools"]}
-egui_glium = "0.19"
+#egui_glium = "0.19"
+egui_glium={git="https://github.com/emilk/egui", rev="eba3927aceedd3052f52b2c0997d5dd858c8e4dd"}
 glium = "0.32"
 winit = {version = "0.27", features = ["serde"]}
 cpal = "0.14.0"

--- a/frontend-egui/src/app.rs
+++ b/frontend-egui/src/app.rs
@@ -15,6 +15,7 @@ use fearless_nes::{Button as NesButton, Nes};
 mod config;
 mod debug;
 mod nesrender;
+mod pause_overlay;
 mod replays;
 mod saves;
 mod settings;
@@ -201,8 +202,12 @@ impl App {
             let nes = nes.lock().unwrap();
 
             let nes_framebuffer = nes.frame_buffer();
-            self.render
-                .draw_nes(nes_framebuffer, egui_ctx, &self.config.overscan);
+            self.render.draw_nes(
+                nes_framebuffer,
+                egui_ctx,
+                &self.config.overscan,
+                self.paused,
+            );
         }
     }
 

--- a/frontend-egui/src/app/config.rs
+++ b/frontend-egui/src/app/config.rs
@@ -15,7 +15,7 @@ use super::nesrender::Overscan;
 
 mod keybinds;
 
-pub use keybinds::Keybinds;
+pub use keybinds::{GetBind, Keybinds};
 
 #[derive(Serialize, Deserialize)]
 pub struct Config {

--- a/frontend-egui/src/app/config/keybinds.rs
+++ b/frontend-egui/src/app/config/keybinds.rs
@@ -100,3 +100,30 @@ impl Keys {
         Self { ctrl, kbd }
     }
 }
+
+///trivial getter for `Keys`.
+///This is done to allow trait bounds.
+pub trait GetBind {
+    fn ctrl(&self) -> &GButton;
+    fn kbd(&self) -> &VirtualKeyCode;
+}
+
+impl GetBind for Keys {
+    fn ctrl(&self) -> &GButton {
+        &self.ctrl
+    }
+
+    fn kbd(&self) -> &VirtualKeyCode {
+        &self.kbd
+    }
+}
+
+impl GetBind for &mut Keys {
+    fn ctrl(&self) -> &GButton {
+        &self.ctrl
+    }
+
+    fn kbd(&self) -> &VirtualKeyCode {
+        &self.kbd
+    }
+}

--- a/frontend-egui/src/app/nesrender.rs
+++ b/frontend-egui/src/app/nesrender.rs
@@ -3,6 +3,8 @@ use serde::{Deserialize, Serialize};
 
 use fearless_nes::{FRAMEBUFFER_SIZE, NES_HEIGHT, NES_WIDTH, PALETTE};
 
+use super::pause_overlay;
+
 pub struct NesRender {
     pub image: ColorImage,
     texture: Option<TextureHandle>,
@@ -21,6 +23,7 @@ impl NesRender {
         nes_framebuffer: &[u8; FRAMEBUFFER_SIZE],
         egui_context: &egui::Context,
         overscan: &Overscan,
+        paused: bool,
     ) {
         for y in 0..NES_HEIGHT {
             for x in 0..NES_WIDTH {
@@ -55,10 +58,14 @@ impl NesRender {
             let rect = Self::calculate_nes_rect(available);
 
             img.paint_at(ui, rect);
+
+            if paused {
+                pause_overlay::pause_overlay(egui_context, rect, paused);
+            }
         });
     }
 
-    fn calculate_nes_size(overscan: &Overscan) -> [f32; 2] {
+    pub fn calculate_nes_size(overscan: &Overscan) -> [f32; 2] {
         let width = NES_WIDTH as f32 - overscan.left as f32 - overscan.right as f32;
         let height = NES_HEIGHT as f32 - overscan.top as f32 - overscan.bottom as f32;
 

--- a/frontend-egui/src/app/pause_overlay.rs
+++ b/frontend-egui/src/app/pause_overlay.rs
@@ -1,6 +1,6 @@
 use std::ops::Add;
 
-use egui::{Color32, Id, Pos2, Rect, Stroke};
+use egui::{Id, Pos2, Rect, Stroke};
 use egui_glium::egui_winit::egui::{self, epaint::PathShape};
 
 const TRIANGLE_SIZE: f32 = 40.0;
@@ -11,13 +11,18 @@ pub fn pause_overlay(egui_ctx: &egui::Context, rect: Rect, paused: bool) {
         order: egui::Order::Middle,
         id: Id::new("pause_overlay"),
     });
-
+    let mut bg = egui_ctx.style().noninteractive().bg_fill;
     let trans = egui_ctx.animate_bool(Id::new("transition"), paused);
-    let bg = egui_ctx.style().noninteractive().bg_fill;
-    let color = if egui_ctx.style().visuals.dark_mode {
-        Color32::from_rgba_premultiplied(bg.r(), bg.g(), bg.b(), (150.0 * trans) as u8)
+
+    //transparent overlay
+    bg[3] = (150.0 * trans) as u8;
+    let (color, contrast_bg) = if egui_ctx.style().visuals.dark_mode {
+        (bg, egui::Visuals::light().noninteractive().bg_fill)
     } else {
-        Color32::from_rgba_unmultiplied(bg.r(), bg.g(), bg.b(), (50.0 * trans) as u8)
+        (
+            bg.linear_multiply(0.1),
+            egui::Visuals::dark().noninteractive().bg_fill,
+        )
     };
     painter.rect_filled(rect, 0.5, color);
 
@@ -33,10 +38,8 @@ pub fn pause_overlay(egui_ctx: &egui::Context, rect: Rect, paused: bool) {
         ],
         Stroke::none(),
     );
-    triangle.fill = if egui_ctx.style().visuals.dark_mode {
-        Color32::from_rgba_premultiplied(bg.r(), bg.g(), bg.b(), (255.0 * trans) as u8)
-    } else {
-        Color32::from_rgba_unmultiplied(bg.r(), bg.g(), bg.b(), (255.0 * trans) as u8)
-    };
+    bg[3] = (255.0 * trans) as u8;
+    triangle.fill = bg;
+    triangle.stroke = Stroke::new(5.0, contrast_bg);
     painter.add(triangle);
 }

--- a/frontend-egui/src/app/pause_overlay.rs
+++ b/frontend-egui/src/app/pause_overlay.rs
@@ -1,0 +1,42 @@
+use std::ops::Add;
+
+use egui::{Color32, Id, Pos2, Rect, Stroke};
+use egui_glium::egui_winit::egui::{self, epaint::PathShape};
+
+const TRIANGLE_SIZE: f32 = 40.0;
+
+///draws a paused overlay over the given `Rect`
+pub fn pause_overlay(egui_ctx: &egui::Context, rect: Rect, paused: bool) {
+    let painter = egui_ctx.layer_painter(egui::LayerId {
+        order: egui::Order::Middle,
+        id: Id::new("pause_overlay"),
+    });
+
+    let trans = egui_ctx.animate_bool(Id::new("transition"), paused);
+    let bg = egui_ctx.style().noninteractive().bg_fill;
+    let color = if egui_ctx.style().visuals.dark_mode {
+        Color32::from_rgba_premultiplied(bg.r(), bg.g(), bg.b(), (150.0 * trans) as u8)
+    } else {
+        Color32::from_rgba_unmultiplied(bg.r(), bg.g(), bg.b(), (50.0 * trans) as u8)
+    };
+    painter.rect_filled(rect, 0.5, color);
+
+    //the play symbol
+    let mut triangle = PathShape::closed_line(
+        vec![
+            rect.center()
+                .add(Pos2::new(-TRIANGLE_SIZE / 1.6, -TRIANGLE_SIZE).to_vec2()),
+            rect.center()
+                .add(Pos2::new(-TRIANGLE_SIZE / 1.6, TRIANGLE_SIZE).to_vec2()),
+            rect.center()
+                .add(Pos2::new(TRIANGLE_SIZE / 1.6, 0.0).to_vec2()),
+        ],
+        Stroke::none(),
+    );
+    triangle.fill = if egui_ctx.style().visuals.dark_mode {
+        Color32::from_rgba_premultiplied(bg.r(), bg.g(), bg.b(), (255.0 * trans) as u8)
+    } else {
+        Color32::from_rgba_unmultiplied(bg.r(), bg.g(), bg.b(), (255.0 * trans) as u8)
+    };
+    painter.add(triangle);
+}

--- a/frontend-egui/src/app/saves.rs
+++ b/frontend-egui/src/app/saves.rs
@@ -57,7 +57,7 @@ impl Saves {
     }
 
     fn load_save(&mut self, save_path: &Path, egui_ctx: &egui::Context) -> Result<()> {
-        let save_file = std::fs::File::open(&save_path)?;
+        let save_file = std::fs::File::open(save_path)?;
         let mut save_archive = zip::ZipArchive::new(&save_file)?;
 
         let screenshot = {
@@ -146,7 +146,7 @@ impl Saves {
             if ui
                 .add(egui::ImageButton::new(
                     &save.texture_handle,
-                    &[NES_WIDTH as f32, NES_HEIGHT as f32],
+                    [NES_WIDTH as f32, NES_HEIGHT as f32],
                 ))
                 .clicked()
             {

--- a/frontend-egui/src/app/settings.rs
+++ b/frontend-egui/src/app/settings.rs
@@ -123,7 +123,7 @@ impl KeybindsUi {
     ) {
         let bind = &mut binds[btn];
 
-        ui.label(btn.name());
+        ui.label(btn.to_string());
 
         let txt_color = ui.style().visuals.text_color();
         let highlight_color = ui.style().visuals.warn_fg_color;

--- a/frontend-egui/src/main.rs
+++ b/frontend-egui/src/main.rs
@@ -67,7 +67,7 @@ fn main() {
                     *control_flow = glutin::event_loop::ControlFlow::Exit;
                 }
 
-                egui_glium.on_event(&event);
+                let _ = egui_glium.on_event(&event);
 
                 match event {
                     WindowEvent::KeyboardInput { input, .. } => app.handle_keyboard_input(input),

--- a/nes/src/apu/blip_buf.rs
+++ b/nes/src/apu/blip_buf.rs
@@ -102,8 +102,8 @@ impl<const S: usize> BlipBuf<S> {
 
     fn add_delta(&mut self, mut delta: i32) {
         // TODO: fix hack
-        let fixed: u32 = (((self.time as u64).wrapping_mul(self.factor) + self.offset)
-            >> Self::PRE_SHIFT) as u32;
+        let fixed: u32 =
+            (((self.time).wrapping_mul(self.factor) + self.offset) >> Self::PRE_SHIFT) as u32;
         let phase = fixed >> Self::PHASE_SHIFT & (Self::PHASE_COUNT - 1);
 
         let interp: i32 =
@@ -122,12 +122,11 @@ impl<const S: usize> BlipBuf<S> {
         buf_index %= S - 15;
 
         for i in 0..8 {
-            self.buf[(buf_index + i) as usize] +=
-                s_in[i as usize] as i32 * delta + in_half_width[i as usize] as i32 * delta2;
+            self.buf[buf_index + i] += s_in[i] as i32 * delta + in_half_width[i] as i32 * delta2;
         }
 
         for (i, j) in (8..16).zip((0..8).rev()) {
-            self.buf[(buf_index + i) as usize] +=
+            self.buf[buf_index + i] +=
                 rev[j as usize] as i32 * delta + rev_half_width[j as usize] as i32 * delta2;
         }
     }

--- a/nes/src/cartridge/gamedb.rs
+++ b/nes/src/cartridge/gamedb.rs
@@ -73,7 +73,7 @@ impl Header {
                 && chr_mmatches
                 && is_normal_nes
             {
-                return Self::parse_game_info(game).map(|gi| Some(gi));
+                return Self::parse_game_info(game).map(Some);
             }
         }
 

--- a/nes/src/controller.rs
+++ b/nes/src/controller.rs
@@ -1,3 +1,5 @@
+use std::fmt;
+
 use bincode::{Decode, Encode};
 
 #[derive(Decode, Encode)]
@@ -64,17 +66,17 @@ pub enum Button {
     Right,
 }
 
-impl Button {
-    pub fn name(self) -> &'static str {
+impl fmt::Display for Button {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Button::A => "A",
-            Button::B => "B",
-            Button::Start => "Start",
-            Button::Select => "Select",
-            Button::Up => "Up",
-            Button::Right => "Right",
-            Button::Down => "Down",
-            Button::Left => "Left",
+            Button::A => write!(f, "A"),
+            Button::B => write!(f, "B"),
+            Button::Start => write!(f, "Start"),
+            Button::Select => write!(f, "Select"),
+            Button::Up => write!(f, "Up"),
+            Button::Right => write!(f, "Right"),
+            Button::Down => write!(f, "Down"),
+            Button::Left => write!(f, "Left"),
         }
     }
 }

--- a/nes/src/cpu.rs
+++ b/nes/src/cpu.rs
@@ -786,7 +786,7 @@ impl Nes {
 
         // Cycle 1
         penultimate_cycle!(self);
-        self.cpu.ab = ((self.cpu.db as u16) << 8) | self.cpu.temp as u16;
+        self.cpu.ab = ((self.cpu.db as u16) << 8) | self.cpu.temp;
         self.cpu.pc = (self.cpu.pc).wrapping_add(1);
 
         self.clock_components();
@@ -811,7 +811,7 @@ impl Nes {
 
         // Cycle 1
         last_cycle!(self);
-        self.cpu.pc = ((self.cpu.db as u16) << 8) | self.cpu.temp as u16;
+        self.cpu.pc = ((self.cpu.db as u16) << 8) | self.cpu.temp;
         self.cpu.ab = self.cpu.pc;
 
         self.clock_components();
@@ -829,7 +829,7 @@ impl Nes {
 
         // Cycle 1
         cycle!(self);
-        self.cpu.ab = ((self.cpu.db as u16) << 8) | self.cpu.temp as u16;
+        self.cpu.ab = ((self.cpu.db as u16) << 8) | self.cpu.temp;
         self.cpu.pc = (self.cpu.pc).wrapping_add(1);
 
         self.clock_components();
@@ -867,8 +867,7 @@ impl Nes {
 
         // Cycle 1
         penultimate_cycle!(self);
-        self.cpu.ab =
-            ((self.cpu.db as u16) << 8) | ((self.cpu.temp as u16 + self.cpu.x as u16) & 0xFF);
+        self.cpu.ab = ((self.cpu.db as u16) << 8) | ((self.cpu.temp + self.cpu.x as u16) & 0xFF);
         self.cpu.pc = (self.cpu.pc).wrapping_add(1);
 
         self.clock_components();
@@ -901,13 +900,12 @@ impl Nes {
 
         // Cycle 1
         penultimate_cycle!(self);
-        self.cpu.ab =
-            ((self.cpu.db as u16) << 8) | ((self.cpu.temp as u16 + self.cpu.y as u16) & 0xFF);
+        self.cpu.ab = ((self.cpu.db as u16) << 8) | ((self.cpu.temp + self.cpu.y as u16) & 0xFF);
         self.cpu.pc = (self.cpu.pc).wrapping_add(1);
 
         self.clock_components();
 
-        if (self.cpu.temp as u16 + self.cpu.y as u16) >= 0x100 {
+        if (self.cpu.temp + self.cpu.y as u16) >= 0x100 {
             // Cycle extra if page boundary was crossed
             penultimate_cycle!(self);
             self.cpu.ab = (self.cpu.ab).wrapping_add(0x100);
@@ -943,7 +941,7 @@ impl Nes {
         // Cycle 2
         penultimate_cycle!(self);
         if (self.cpu.temp + self.cpu.x as u16) >= 0x100 {
-            self.cpu.ab = (self.cpu.ab as u16).wrapping_add(0x100);
+            self.cpu.ab = self.cpu.ab.wrapping_add(0x100);
         };
 
         self.clock_components();
@@ -976,7 +974,7 @@ impl Nes {
         // Cycle 2
         penultimate_cycle!(self);
         if (self.cpu.temp + self.cpu.y as u16) >= 0x100 {
-            self.cpu.ab = (self.cpu.ab as u16).wrapping_add(0x100);
+            self.cpu.ab = self.cpu.ab.wrapping_add(0x100);
         };
 
         self.clock_components();
@@ -1047,7 +1045,7 @@ impl Nes {
 
         // Cycle 1
         cycle!(self);
-        self.cpu.ab = ((self.cpu.db as u16) << 8) | self.cpu.temp as u16;
+        self.cpu.ab = ((self.cpu.db as u16) << 8) | self.cpu.temp;
 
         self.clock_components();
 
@@ -1060,7 +1058,7 @@ impl Nes {
 
         // Cycle 3
         last_cycle!(self);
-        self.cpu.pc = ((self.cpu.db as u16) << 8) | self.cpu.temp as u16;
+        self.cpu.pc = ((self.cpu.db as u16) << 8) | self.cpu.temp;
         self.cpu.ab = self.cpu.pc;
 
         self.clock_components();
@@ -1090,7 +1088,7 @@ impl Nes {
 
         // Cycle 3
         penultimate_cycle!(self);
-        self.cpu.ab = ((self.cpu.db as u16) << 8) | self.cpu.temp as u16;
+        self.cpu.ab = ((self.cpu.db as u16) << 8) | self.cpu.temp;
 
         self.clock_components();
 
@@ -1126,7 +1124,7 @@ impl Nes {
 
         // Cycle 3
         penultimate_cycle!(self);
-        self.cpu.ab = ((self.cpu.db as u16) << 8) | self.cpu.temp as u16;
+        self.cpu.ab = ((self.cpu.db as u16) << 8) | self.cpu.temp;
 
         self.clock_components();
 
@@ -1162,7 +1160,7 @@ impl Nes {
 
         // Cycle 3
         cycle!(self);
-        self.cpu.ab = ((self.cpu.db as u16) << 8) | self.cpu.temp as u16;
+        self.cpu.ab = ((self.cpu.db as u16) << 8) | self.cpu.temp;
 
         self.clock_components();
 
@@ -1250,7 +1248,7 @@ impl Nes {
         // Cycle 3
         cycle!(self);
         if (self.cpu.temp + self.cpu.y as u16) >= 0x100 {
-            self.cpu.ab = (self.cpu.ab as u16).wrapping_add(0x100);
+            self.cpu.ab = self.cpu.ab.wrapping_add(0x100);
         };
 
         self.clock_components();
@@ -1326,7 +1324,7 @@ impl Nes {
 
         // Cycle 1
         penultimate_cycle!(self);
-        self.cpu.ab = ((self.cpu.db as u16) << 8) | self.cpu.temp as u16;
+        self.cpu.ab = ((self.cpu.db as u16) << 8) | self.cpu.temp;
         self.cpu.pc = (self.cpu.pc).wrapping_add(1);
 
         self.clock_components();
@@ -1397,14 +1395,14 @@ impl Nes {
 
         // Cycle 1
         cycle!(self);
-        self.cpu.sp = (self.cpu.sp as u8).wrapping_sub(1);
+        self.cpu.sp = (self.cpu.sp).wrapping_sub(1);
 
         self.clock_components();
 
         // Cycle 2
         self.cpu_write(self.cpu.ab as usize, (self.cpu.pc >> 8) as u8);
         self.sp_to_ab();
-        self.cpu.sp = (self.cpu.sp as u8).wrapping_sub(1);
+        self.cpu.sp = (self.cpu.sp).wrapping_sub(1);
 
         self.clock_components();
 
@@ -1417,7 +1415,7 @@ impl Nes {
 
         // Cycle 4
         last_cycle!(self);
-        self.cpu.pc = ((self.cpu.db as u16) << 8) | self.cpu.temp as u16;
+        self.cpu.pc = ((self.cpu.db as u16) << 8) | self.cpu.temp;
         self.cpu.ab = self.cpu.pc;
 
         self.clock_components();
@@ -1427,10 +1425,10 @@ impl Nes {
     fn brk(&mut self) {
         // Cycle 0
         cycle!(self);
-        let int = if self.cpu.take_interrupt { 0 } else { 1 };
+        let int = u16::from(!self.cpu.take_interrupt);
         self.cpu.pc += int;
         self.sp_to_ab();
-        self.cpu.sp = (self.cpu.sp as u8).wrapping_sub(1);
+        self.cpu.sp = (self.cpu.sp).wrapping_sub(1);
 
         self.clock_components();
 
@@ -1439,7 +1437,7 @@ impl Nes {
             self.cpu_write(self.cpu.ab as usize, (self.cpu.pc >> 8) as u8);
         }
         self.sp_to_ab();
-        self.cpu.sp = (self.cpu.sp as u8).wrapping_sub(1);
+        self.cpu.sp = (self.cpu.sp).wrapping_sub(1);
 
         self.clock_components();
 
@@ -1448,7 +1446,7 @@ impl Nes {
             self.cpu_write(self.cpu.ab as usize, (self.cpu.pc & 0xFF) as u8);
         }
         self.sp_to_ab();
-        self.cpu.sp = (self.cpu.sp as u8).wrapping_sub(1);
+        self.cpu.sp = (self.cpu.sp).wrapping_sub(1);
 
         self.clock_components();
 
@@ -1472,7 +1470,7 @@ impl Nes {
 
         // Cycle 5
         cycle!(self);
-        self.cpu.pc = ((self.cpu.db as u16) << 8) | self.cpu.temp as u16;
+        self.cpu.pc = ((self.cpu.db as u16) << 8) | self.cpu.temp;
         self.cpu.ab = self.cpu.pc;
 
         self.clock_components();
@@ -1488,7 +1486,7 @@ impl Nes {
 
         // Cycle 1
         cycle!(self);
-        self.cpu.sp = (self.cpu.sp as u8).wrapping_add(1);
+        self.cpu.sp = (self.cpu.sp).wrapping_add(1);
 
         self.sp_to_ab();
 
@@ -1497,7 +1495,7 @@ impl Nes {
         // Cycle 2
         cycle!(self);
         self.pull_status(self.cpu.db);
-        self.cpu.sp = (self.cpu.sp as u8).wrapping_add(1);
+        self.cpu.sp = (self.cpu.sp).wrapping_add(1);
 
         self.sp_to_ab();
 
@@ -1506,7 +1504,7 @@ impl Nes {
         // Cycle 3
         penultimate_cycle!(self);
         self.cpu.temp = self.cpu.db as u16;
-        self.cpu.sp = (self.cpu.sp as u8).wrapping_add(1);
+        self.cpu.sp = (self.cpu.sp).wrapping_add(1);
 
         self.sp_to_ab();
 
@@ -1514,7 +1512,7 @@ impl Nes {
 
         // Cycle 4
         last_cycle!(self);
-        self.cpu.pc = ((self.cpu.db as u16) << 8) | self.cpu.temp as u16;
+        self.cpu.pc = ((self.cpu.db as u16) << 8) | self.cpu.temp;
         self.cpu.ab = self.cpu.pc;
 
         self.clock_components();
@@ -1530,7 +1528,7 @@ impl Nes {
 
         // Cycle 1
         cycle!(self);
-        self.cpu.sp = (self.cpu.sp as u8).wrapping_add(1);
+        self.cpu.sp = (self.cpu.sp).wrapping_add(1);
         self.sp_to_ab();
 
         self.clock_components();
@@ -1538,14 +1536,14 @@ impl Nes {
         // Cycle 2
         cycle!(self);
         self.cpu.temp = self.cpu.db as u16;
-        self.cpu.sp = (self.cpu.sp as u8).wrapping_add(1);
+        self.cpu.sp = (self.cpu.sp).wrapping_add(1);
         self.sp_to_ab();
 
         self.clock_components();
 
         // Cycle 3
         penultimate_cycle!(self);
-        self.cpu.pc = ((self.cpu.db as u16) << 8) | self.cpu.temp as u16;
+        self.cpu.pc = ((self.cpu.db as u16) << 8) | self.cpu.temp;
         self.cpu.ab = self.cpu.pc;
 
         self.clock_components();
@@ -1564,7 +1562,7 @@ impl Nes {
         // Cycle 0
         penultimate_cycle!(self);
         self.sp_to_ab();
-        self.cpu.sp = (self.cpu.sp as u8).wrapping_sub(1);
+        self.cpu.sp = (self.cpu.sp).wrapping_sub(1);
         self.clock_components();
 
         // Cycle 1
@@ -1580,7 +1578,7 @@ impl Nes {
         // Cycle 0
         penultimate_cycle!(self);
         self.sp_to_ab();
-        self.cpu.sp = (self.cpu.sp as u8).wrapping_sub(1);
+        self.cpu.sp = (self.cpu.sp).wrapping_sub(1);
         self.clock_components();
 
         // Cycle 1
@@ -1601,7 +1599,7 @@ impl Nes {
 
         // Cycle 1
         penultimate_cycle!(self);
-        self.cpu.sp = (self.cpu.sp as u8).wrapping_add(1);
+        self.cpu.sp = (self.cpu.sp).wrapping_add(1);
         self.sp_to_ab();
 
         self.clock_components();
@@ -1624,7 +1622,7 @@ impl Nes {
 
         // Cycle 1
         penultimate_cycle!(self);
-        self.cpu.sp = (self.cpu.sp as u8).wrapping_add(1);
+        self.cpu.sp = (self.cpu.sp).wrapping_add(1);
         self.sp_to_ab();
 
         self.clock_components();
@@ -1649,7 +1647,7 @@ impl Nes {
             & (1 << 8)
             != 0;
         let num: i8 = (num as i8).wrapping_add(if self.cpu.c { 1 } else { 0 });
-        let num: i8 = (num as i8).wrapping_add(self.cpu.a as i8);
+        let num: i8 = num.wrapping_add(self.cpu.a as i8);
         self.cpu.a = num as u8;
         self.cpu.v = (a ^ b) & (0x80) == 0 && (a ^ self.cpu.a) & 0x80 != 0;
         self.cpu.c = carry;
@@ -1889,7 +1887,7 @@ impl Nes {
 
     #[inline]
     fn tsx(&mut self) {
-        self.cpu.x = self.cpu.sp as u8;
+        self.cpu.x = self.cpu.sp;
         self.set_z_n(self.cpu.x);
     }
 
@@ -2014,8 +2012,8 @@ impl Nes {
     #[inline]
     fn las(&mut self, val: u8) {
         self.cpu.sp &= val;
-        self.cpu.a = self.cpu.sp as u8;
-        self.cpu.x = self.cpu.sp as u8;
+        self.cpu.a = self.cpu.sp;
+        self.cpu.x = self.cpu.sp;
         self.set_z_n(self.cpu.a);
     }
 

--- a/nes/src/ppu.rs
+++ b/nes/src/ppu.rs
@@ -1138,7 +1138,7 @@ impl Nes {
                 let spr = &mut self.ppu.sprite_buffer[i as usize];
                 let shift = self.ppu.xpos as i32 - spr.x as i32 - 1;
 
-                if shift >= 0 && shift <= 7 {
+                if (0..=7).contains(&shift) {
                     let sp_color = if spr.horizontal_flip {
                         ((spr.tile_low >> shift) & 1) | (((spr.tile_high >> shift) & 1) << 1)
                     } else {


### PR DESCRIPTION

![improvement](https://user-images.githubusercontent.com/86922687/196796202-1c32e441-b17e-4e66-8e2c-d66b6a71e18e.png)

When I came across [Fearless-NES](https://github.com/TomasKralCZ/Fearless-NES) I was disappointed to find out that the display seemed blurry when running the native [egui](https://github.com/emilk/egui) client. After some digging I found out that the issue lay with the actual [egui_glium](https://github.com/emilk/egui/tree/master/crates/egui_glium) implementation. As discussed in this [issue](https://github.com/emilk/egui/issues/1961), egui_glium 0.19.0 ignores the [`TextureFilter`](https://docs.rs/egui/0.19.0/egui/enum.TextureFilter.html#variant.Linear) which is supposed to make things crisp. This is addressed in this [commit](https://github.com/emilk/egui/commit/f3f6946eb23379327965059235b14e6a02182827) although it has not made it into the current 0.19.0 release. What I did is simply change the version of egui_glium in `Cargo.toml` to have the fix from the commit. This does mean we are using an unreleased version of egui_glium, though I have yet to come across any issues. Besides, I doubt there are any as major as the current error. The emulator looks borderline unplayable in retrospect.